### PR TITLE
Use STDOUT to STDERR redirection

### DIFF
--- a/git-pair
+++ b/git-pair
@@ -47,7 +47,7 @@ function gp_reset_author()
 }
 
 if [ -z "$1" ]; then
-	cat <<-CAT
+	cat 1>&2 <<-CAT
 	Usage: git pair <author name>
 	       git pair ended
 


### PR DESCRIPTION
Prevents other scripts from catching the output of STDOUT as a
successfull issue of the command when no arguments are given.
