### PR TITLE
Avoid to pair programming with repetitive authors (#4)

### DIFF
--- a/git-pair
+++ b/git-pair
@@ -30,6 +30,8 @@ function gp_add_author()
 	[[ -z "$1" ]] && { echo "Pair name is required, like 'John Doe'."; exit 100; }
 
 	CURRENT_AUTHORS=$(git config user.name)
+	[[ $( echo $CURRENT_AUTHORS | grep -e "$PAIR_NAME" ) != "" ]] && { echo "You cannot pair with yourself, can you?"; exit 102;  }
+
 	PAIR_NAMES="${CURRENT_AUTHORS} ${PAIR_SEPARATOR} ${PAIR_NAME}"
 
 	git config --local user.name "$PAIR_NAMES"

--- a/tests/failed_attempts_to_pair.bats
+++ b/tests/failed_attempts_to_pair.bats
@@ -37,3 +37,12 @@ load git_environment
     assert_failure
     #assert_equals "Git is not installed, moron!" "$output"
 }
+
+@test "Should not pair with an author already existent" {
+    run git-pair "Billie Jean"
+    run git-pair "Billie Jean"
+
+    assert_failure
+    assert_equals "You cannot pair with yourself, can you?" "$output"
+}
+


### PR DESCRIPTION
If an author already is in pair programming, he should not be added again. 
